### PR TITLE
feat: Always perform window enumeration on the main thread

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+      - name: Select
+        run: sudo xcode-select -switch /Applications/XCode_14.3.1.app
       - name: Build and test
         run: |
           xcodebuild test \

--- a/Sources/Trap/Constants.swift
+++ b/Sources/Trap/Constants.swift
@@ -1,5 +1,5 @@
 struct Constants {
     struct App {
-        static let version = "1.1.3"
+        static let version = "1.1.4"
     }
 }

--- a/Sources/Trap/Datasource/Gesture/Gesture.swift
+++ b/Sources/Trap/Datasource/Gesture/Gesture.swift
@@ -134,9 +134,19 @@ open class TrapGestureCollector {
         }
 
         // Finally, add a recognizer to all current windows
-        for window in UIApplication.shared.windows {
-            if !recognizers.keys.contains(window.hash) {
-                addRecognizers(to: window)
+        let addRecognizers = {
+            for window in UIApplication.shared.windows {
+                if !self.recognizers.keys.contains(window.hash) {
+                    self.addRecognizers(to: window)
+                }
+            }
+        }
+        
+        if Thread.isMainThread {
+            addRecognizers()
+        } else {
+            DispatchQueue.main.async {
+                addRecognizers()
             }
         }
     }
@@ -152,8 +162,17 @@ open class TrapGestureCollector {
         }
 
         // Finally remove all the active recognizers
-        for window in UIApplication.shared.windows {
-            removeRecognizers(from: window)
+        let removeRecognizers = {
+            for window in UIApplication.shared.windows {
+                self.removeRecognizers(from: window)
+            }
+        }
+        if Thread.isMainThread {
+            removeRecognizers()
+        } else {
+            DispatchQueue.main.sync {
+                removeRecognizers()
+            }
         }
     }
 


### PR DESCRIPTION
It is not guaranteed that the subscribe and unsubscribe methods are called from the main thread, but window enumeration should always happen on the main thread. To ensure it the window enumeration has to be dispatched to the main thread.